### PR TITLE
Add assertions to enforce invariants

### DIFF
--- a/data/tika.txt
+++ b/data/tika.txt
@@ -1,5 +1,1 @@
-D | 1 | return book | 2026-02-05 1800
-E | 0 | project meeting | 2026-02-06 1400 | 2026-02-06 1600
-T | 0 | fly
-T | 1 | book club meeting
-T | 0 | eat food
+T | 0 | fly away

--- a/src/main/java/tika/Parser.java
+++ b/src/main/java/tika/Parser.java
@@ -5,12 +5,16 @@ import java.time.format.DateTimeParseException;
 public class Parser {
 
     public static String getCommandWord(String input) {
+        assert !input.isBlank() : "Input should not be blank";
         return input.split(" ")[0];
     }
 
     public static int parseIndex(String input) throws TikaException {
+        String[] parts = input.split(" ");
+        assert parts.length >= 2 : "Indexed command should at least have 2 parts";
+
         try {
-            return Integer.parseInt(input.split(" ")[1]);
+            return Integer.parseInt(parts[1]);
         } catch (NumberFormatException e) {
             throw new TikaException("Invalid index! Must be an integer.");
         }
@@ -22,6 +26,7 @@ public class Parser {
     }
 
     public static String parseKeyword(String input) throws TikaException {
+        assert !input.isBlank() : "Task input should not be blank";
         String[] parts = input.split(" ", 2);
 
         if (parts.length < 2 || parts[1].isBlank()) {
@@ -32,6 +37,8 @@ public class Parser {
     }
 
     public static Task parseTask(String input) throws TikaException {
+        assert !input.isBlank() : "Task input should not be blank";
+
         String command = getCommandWord(input);
 
         switch (command) {

--- a/src/main/java/tika/Tika.java
+++ b/src/main/java/tika/Tika.java
@@ -12,6 +12,8 @@ public class Tika {
         ui = new Ui();
         storage = new Storage();
         taskList = new TaskList(storage.load());
+
+        assert taskList != null : "TaskList should not be null after loading storage";
     }
 
     /**
@@ -56,6 +58,10 @@ public class Tika {
         }
         int number = Parser.parseIndex(input);
 
+        if (number == 0) {
+            throw new TikaException("Type something!");
+        }
+
         if (number > taskList.size()) {
             throw new TikaException("Not a valid task!");
         }
@@ -80,8 +86,12 @@ public class Tika {
             return ui.unmarkTask(task);
 
         case "delete":
+            int oldSize = taskList.size();
             taskList.remove(number - 1);
             storage.save(taskList.getTasks());
+
+            assert taskList.size() == oldSize - 1 : "TaskList size should decrease after deletion";
+
             return ui.deleteTask(task, taskList.size());
 
         default:
@@ -120,6 +130,7 @@ public class Tika {
 
     private String addTask(String input) throws TikaException {
         Task task = Parser.parseTask(input);
+        assert task != null : "Parsed task should not be null";
         taskList.add(task);
         storage.save(taskList.getTasks());
         return ui.addTask(task, taskList.size());


### PR DESCRIPTION
Parser and Tika class do not enforce internal invariants

Assumptions about input validity and parsed input lengths are not documented or checked. This can lead to bugs in development.

Add assertions in Parser and Tika class to check for non-null inputs, valid input lengths, and proper task creation.

Assertions document developer assumptions and catches internal bugs early on without affecting the handling of user mishandling, which is handled by exceptions